### PR TITLE
Add support for parsing float literal 

### DIFF
--- a/src/lexer/lexer_test.go
+++ b/src/lexer/lexer_test.go
@@ -26,13 +26,14 @@ if (5 < 10) {
 10 == 10;
 10 != 9;
 5 ** 5;
+let a = 9.5
 `
 	expectedResult := []struct {
-		expectedType token.TokenType
+		expectedType    token.TokenType
 		expectedLiteral string
-		ln int
-		col int
-	} {
+		ln              int
+		col             int
+	}{
 		{token.LET, "let", 1, 1},
 		{token.IDENT, "🚀five", 1, 5},
 		{token.ASSIGN, "=", 1, 11},
@@ -110,7 +111,11 @@ if (5 < 10) {
 		{token.EXPONENT, "**", 20, 3},
 		{token.INT, "5", 20, 6},
 		{token.SEMICOLON, ";", 20, 7},
-		{token.EOF, "", 21, 2},
+		{token.LET, "let", 21, 1},
+		{token.IDENT, "a", 21, 5},
+		{token.ASSIGN, "=", 21, 7},
+		{token.FLOAT, "9.5", 21, 9},
+		{token.EOF, "", 22, 2},
 	}
 
 	l := New(input)

--- a/src/token/token.go
+++ b/src/token/token.go
@@ -5,14 +5,14 @@ import "fmt"
 type TokenType string
 
 type Token struct {
-	Type TokenType
+	Type    TokenType
 	Literal string
-	Ln int
-	Col int
+	Ln      int
+	Col     int
 }
 
 func New(t TokenType, l string, ln int, col int) Token {
-	return Token{Type: t, Literal: l, Ln: ln, Col: col }
+	return Token{Type: t, Literal: l, Ln: ln, Col: col}
 }
 
 func (tok *Token) Inspect() {
@@ -27,6 +27,7 @@ const (
 	IDENT  = "IDENT"  // add, foobar, x, y, ...
 	INT    = "INT"    // 1343456
 	STRING = "STRING" // "foobar" // todo:
+	FLOAT  = "FLOAT"
 
 	// Operators
 	ASSIGN   = "="
@@ -69,11 +70,11 @@ const (
 )
 
 var Keywords = map[string]TokenType{
-	"func": FUNCTION,
-	"let": LET,
+	"func":   FUNCTION,
+	"let":    LET,
 	"return": RETURN,
-	"true": TRUE,
-	"false": FALSE,
-	"if": IF,
-	"else": ELSE, 
+	"true":   TRUE,
+	"false":  FALSE,
+	"if":     IF,
+	"else":   ELSE,
 }


### PR DESCRIPTION
The `parseNumber` function has been modified to handle both integer and float literals, and the necessary logic has been added to the NextToken function to create the appropriate token types (`token.INT` and `token.FLOAT`) based on the parsed literals.

Note: Added tests covering floats literal.